### PR TITLE
Feature: upgrade to Laravel 11 and drop support for PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2]
-        testing: [4.1, 5]
+        php: [8.2, 8.3]
 
     steps:
     - name: Checkout Code
@@ -29,9 +28,6 @@ jobs:
         tools: composer:v2
         coverage: none
         ini-values: error_reporting=E_ALL
-
-    - name: Set Testing Version
-      run: composer require "cloudcreativity/json-api-testing:^${{ matrix.testing }}" --no-update
 
     - name: Install dependencies
       uses: nick-fields/retry@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file. This project adheres to
 [Semantic Versioning](http://semver.org/) and [this changelog format](http://keepachangelog.com/).
 
+## Unreleased (Laravel 11)
+
+### Changed
+
+- **BREAKING** Package now requires Laravel 11.
+- **BREAKING** Package now requires `cloudcreativity/json-api-testing` version 6.
+- Minimum PHP version is now `8.2`.
+
 ## [2.1.0] - 2023-02-18
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -23,16 +23,16 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-json": "*",
-        "cloudcreativity/json-api-testing": "^4.1|^5.0",
-        "illuminate/http": "^10.0",
-        "illuminate/support": "^10.0",
-        "illuminate/testing": "^10.0"
+        "cloudcreativity/json-api-testing": "^6.0",
+        "illuminate/http": "^11.0",
+        "illuminate/support": "^11.0",
+        "illuminate/testing": "^11.0"
     },
     "require-dev": {
-        "laravel/framework": "^10.0",
-        "phpunit/phpunit": "^9.5.28|^10.0.7"
+        "laravel/framework": "^11.0",
+        "phpunit/phpunit": "^10.5"
     },
     "autoload": {
         "psr-4": {
@@ -46,10 +46,11 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "2.x-dev"
+            "dev-develop": "2.x-dev",
+            "dev-laravel11": "3.x-dev"
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -46,11 +46,10 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "2.x-dev",
-            "dev-laravel11": "3.x-dev"
+            "dev-develop": "3.x-dev"
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "config": {
         "sort-packages": true

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,14 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false"
-         beStrictAboutTestsThatDoNotTestAnything="false" bootstrap="vendor/autoload.php" colors="true"
-         processIsolation="false" stopOnError="false" stopOnFailure="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache"
-         backupStaticProperties="false">
-    <coverage>
-        <include>
-            <directory suffix=".php">src/</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false"
+         failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
+>
+    <coverage/>
     <testsuites>
         <testsuite name="Unit">
             <directory suffix="Test.php">./tests/Unit/</directory>
@@ -19,6 +25,10 @@
     </testsuites>
     <php>
         <ini name="error_reporting" value="E_ALL"/>
-        <env name="DB_CONNECTION" value="testing"/>
     </php>
+    <source>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
This PR upgrades to Laravel 11, dropping support for PHP 8.1 at the same time.

The `cloudcreativity/json-api-testing` package has been upgraded to v6.