### PR TITLE
fix php 8.4 deprecation notice

### DIFF
--- a/src/MakesJsonApiRequests.php
+++ b/src/MakesJsonApiRequests.php
@@ -19,7 +19,7 @@ trait MakesJsonApiRequests
      *      the expected resource type.
      * @return TestBuilder
      */
-    protected function jsonApi(string $expects = null): TestBuilder
+    protected function jsonApi(?string $expects = null): TestBuilder
     {
         $tester = new TestBuilder($this);
 


### PR DESCRIPTION
```
Deprecated: LaravelJsonApi\Testing\MakesJsonApiRequests::jsonApi(): Implicitly marking parameter $expects as nullable is deprecated, the explicit nullable type must be used instead
```